### PR TITLE
fix: scope Tailwind styles to Shadow DOM in content script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ vite.config.d.ts
 *.sln
 *.sw?
 .yarn/install-state.gz
+
+# Playwright
+test-results/
+playwright-report/

--- a/content-script/src/main.tsx
+++ b/content-script/src/main.tsx
@@ -1,16 +1,25 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import "@lib/styles/globals.css";
+import styles from "@lib/styles/globals.css?inline";
 import App from "./App";
 
 const existing = document.getElementById("extension-root");
-const container = existing ?? document.createElement("div");
+const host = existing ?? document.createElement("div");
 if (!existing) {
-  container.id = "extension-root";
-  document.body.appendChild(container);
+  host.id = "extension-root";
+  document.body.appendChild(host);
 }
 
-createRoot(container).render(
+const shadowRoot = host.shadowRoot ?? host.attachShadow({ mode: "open" });
+
+const style = document.createElement("style");
+style.textContent = styles;
+shadowRoot.appendChild(style);
+
+const mountPoint = document.createElement("div");
+shadowRoot.appendChild(mountPoint);
+
+createRoot(mountPoint).render(
   <StrictMode>
     <App />
   </StrictMode>

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       "devDependencies": {
         "@crxjs/vite-plugin": "^2.3.0",
         "@eslint/js": "^9.17.0",
+        "@playwright/test": "^1.58.2",
         "@types/chrome": "^0.0.287",
         "@types/node": "^24.0.0",
         "@types/react": "^19.0.2",
@@ -1100,6 +1101,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -3678,6 +3695,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "setup": "node scripts/setup.js"
+    "setup": "node scripts/setup.js",
+    "test": "playwright test"
   },
   "dependencies": {
     "react": "^19.0.0",
@@ -22,6 +23,7 @@
   "devDependencies": {
     "@crxjs/vite-plugin": "^2.3.0",
     "@eslint/js": "^9.17.0",
+    "@playwright/test": "^1.58.2",
     "@types/chrome": "^0.0.287",
     "@types/node": "^24.0.0",
     "@types/react": "^19.0.2",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests",
+  use: {
+    ...devices["Desktop Chrome"],
+  },
+});

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/tests/preflight-isolation.spec.ts
+++ b/tests/preflight-isolation.spec.ts
@@ -1,0 +1,86 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * A representative subset of Tailwind Preflight that resets h1 styles.
+ * Full Preflight does the same thing across all heading, body, and element selectors.
+ */
+const PREFLIGHT_SNIPPET = `
+  h1, h2, h3, h4, h5, h6 { font-size: inherit; font-weight: inherit; margin: 0; }
+  body { margin: 0; }
+`;
+
+/**
+ * A minimal host page simulating a real site the extension would run on.
+ * Browser defaults: h1 has margin (~10.7px top) and font-size (32px = 2em).
+ */
+const HOST_PAGE = `
+  <!DOCTYPE html>
+  <html>
+    <body>
+      <nav><a href="#">Nav link</a></nav>
+      <h1>Host page heading</h1>
+    </body>
+  </html>
+`;
+
+test.describe("Tailwind Preflight isolation", () => {
+  test("reproduces issue: global CSS injection leaks Preflight into host page", async ({
+    page,
+  }) => {
+    await page.setContent(HOST_PAGE);
+
+    const before = await page.evaluate(() => ({
+      h1MarginTop: getComputedStyle(document.querySelector("h1")!).marginTop,
+      h1FontSize: getComputedStyle(document.querySelector("h1")!).fontSize,
+    }));
+
+    expect(before.h1MarginTop).not.toBe("0px");
+    expect(before.h1FontSize).not.toBe("16px");
+
+    await page.evaluate((css) => {
+      const style = document.createElement("style");
+      style.textContent = css;
+      document.head.appendChild(style);
+    }, PREFLIGHT_SNIPPET);
+
+    const after = await page.evaluate(() => ({
+      h1MarginTop: getComputedStyle(document.querySelector("h1")!).marginTop,
+      h1FontSize: getComputedStyle(document.querySelector("h1")!).fontSize,
+    }));
+
+    expect(after.h1MarginTop).toBe("0px");
+    expect(after.h1FontSize).toBe("16px");
+  });
+
+  test("fix: Shadow DOM scopes Preflight away from host page", async ({
+    page,
+  }) => {
+    await page.setContent(HOST_PAGE);
+
+    const before = await page.evaluate(() => ({
+      h1MarginTop: getComputedStyle(document.querySelector("h1")!).marginTop,
+      h1FontSize: getComputedStyle(document.querySelector("h1")!).fontSize,
+    }));
+
+    expect(before.h1MarginTop).not.toBe("0px");
+    expect(before.h1FontSize).not.toBe("16px");
+
+    await page.evaluate((css) => {
+      const host = document.createElement("div");
+      host.id = "extension-root";
+      document.body.appendChild(host);
+      const shadowRoot = host.attachShadow({ mode: "open" });
+      const style = document.createElement("style");
+      style.textContent = css;
+      shadowRoot.appendChild(style);
+    }, PREFLIGHT_SNIPPET);
+
+    const after = await page.evaluate(() => ({
+      h1MarginTop: getComputedStyle(document.querySelector("h1")!).marginTop,
+      h1FontSize: getComputedStyle(document.querySelector("h1")!).fontSize,
+    }));
+
+    expect(after.h1MarginTop).not.toBe("0px");
+    expect(after.h1FontSize).not.toBe("16px");
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes Tailwind Preflight leaking into host page styles when the content script is injected
- Mounts the React app inside a Shadow DOM, scoping all extension styles away from the host page
- Adds Playwright tests that reproduce the CSS leak and verify the fix

## What changed

- `content-script/src/main.tsx`: attaches a shadow root to the host element, injects compiled CSS into it, and renders React into a mount point inside the shadow root
- `src/vite-env.d.ts`: adds `vite/client` types to support the `?inline` CSS import
- `playwright.config.ts` + `tests/preflight-isolation.spec.ts`: two tests using real Chromium computed styles — one reproducing the leak, one verifying the fix
- `.gitignore`: excludes Playwright artifacts

Closes #24